### PR TITLE
Add github actions to push to ecr and trigger deployment

### DIFF
--- a/.github/workflows/push-image-ecr.yaml
+++ b/.github/workflows/push-image-ecr.yaml
@@ -1,0 +1,44 @@
+name: Build and push docker container
+
+on: [workflow_dispatch]
+
+jobs:
+  # test-server: TODO?
+
+  build-push:
+    runs-on: ubuntu-latest
+    # needs: test-server
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push docker image to Amazon ECR
+        id: push-image
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: common-voice
+          IMAGE_TAG: prod-${{ github.sha }}
+        run: |
+          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+          CURRENT_UID=$(id -u):$(id -g) docker-compose --project-name "common-voice" -f "docker-compose.yaml" build web
+          docker tag common-voice_web:latest $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+
+      - name: Repository dispatch to trigger deployment
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.PAT }}
+          repository: nigeldecontie/Common-Voice.aws
+          event-type: cv-deployment
+          client-payload: '{"tag": "${{ steps.push-image.outputs.image_tag }}"}'


### PR DESCRIPTION
Add GitHub Action to push to ECR and trigger deployment in infrastructure repo:
1. Checks out repo
2. Configures AWS credentials
3. Builds image
4. Tags image
5. Pushes to ECR
6. Triggers the infrastructure repo to deploy new image

- Currently deploys manually, we may want to specify a branch for automatic trigger
- Tags image with GitHub sha